### PR TITLE
Added cpt Course Topics with custom icon positioned above Posts in ad…

### DIFF
--- a/html/wp-content/themes/escapade-primer-child/functions.php
+++ b/html/wp-content/themes/escapade-primer-child/functions.php
@@ -390,3 +390,54 @@ function escapade_color_schemes( $color_schemes ) {
 
 }
 add_filter( 'primer_color_schemes', 'escapade_color_schemes' );
+
+// Custom Post Types
+// *********************************
+function course_topic_init() {
+	$labels = array(
+			'name'                  => _x( 'Course Topics', 'Post type general name', 'textdomain' ),
+			'singular_name'         => _x( 'Course Topic', 'Post type singular name', 'textdomain' ),
+			'menu_name'             => _x( 'Course Topics', 'Admin Menu text', 'textdomain' ),
+			'name_admin_bar'        => _x( 'Course Topic', 'Add New on Toolbar', 'textdomain' ),
+			'add_new'               => __( 'Add New', 'textdomain' ),
+			'add_new_item'          => __( 'Add New Course Topic', 'textdomain' ),
+			'new_item'              => __( 'New Course Topic', 'textdomain' ),
+			'edit_item'             => __( 'Edit Course Topic', 'textdomain' ),
+			'view_item'             => __( 'View Course Topic', 'textdomain' ),
+			'all_items'             => __( 'All Course Topics', 'textdomain' ),
+			'search_items'          => __( 'Search Course Topics', 'textdomain' ),
+			'parent_item_colon'     => __( 'Parent Course Topics:', 'textdomain' ),
+			'not_found'             => __( 'No Course Topics found.', 'textdomain' ),
+			'not_found_in_trash'    => __( 'No Course Topics found in Trash.', 'textdomain' ),
+			'featured_image'        => _x( 'Course Topic Cover Image', 'Overrides the “Featured Image” phrase for this post type. Added in 4.3', 'textdomain' ),
+			'set_featured_image'    => _x( 'Set cover image', 'Overrides the “Set featured image” phrase for this post type. Added in 4.3', 'textdomain' ),
+			'remove_featured_image' => _x( 'Remove cover image', 'Overrides the “Remove featured image” phrase for this post type. Added in 4.3', 'textdomain' ),
+			'use_featured_image'    => _x( 'Use as cover image', 'Overrides the “Use as featured image” phrase for this post type. Added in 4.3', 'textdomain' ),
+			'archives'              => _x( 'Course Topic archives', 'The post type archive label used in nav menus. Default “Post Archives”. Added in 4.4', 'textdomain' ),
+			'insert_into_item'      => _x( 'Insert into course topic', 'Overrides the “Insert into post”/”Insert into page” phrase (used when inserting media into a post). Added in 4.4', 'textdomain' ),
+			'uploaded_to_this_item' => _x( 'Uploaded to this course topic', 'Overrides the “Uploaded to this post”/”Uploaded to this page” phrase (used when viewing media attached to a post). Added in 4.4', 'textdomain' ),
+			'filter_items_list'     => _x( 'Filter course topics list', 'Screen reader text for the filter links heading on the post type listing screen. Default “Filter posts list”/”Filter pages list”. Added in 4.4', 'textdomain' ),
+			'items_list_navigation' => _x( 'Course Topics list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default “Posts list navigation”/”Pages list navigation”. Added in 4.4', 'textdomain' ),
+			'items_list'            => _x( 'Course Topics list', 'Screen reader text for the items list heading on the post type listing screen. Default “Posts list”/”Pages list”. Added in 4.4', 'textdomain' ),
+	);
+
+	$args = array(
+			'labels'             => $labels,
+			'public'             => true,
+			'menu_icon'   => 'dashicons-lightbulb',
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'query_var'          => true,
+			'rewrite'            => array( 'slug' => 'course topic' ),
+			'capability_type'    => 'post',
+			'has_archive'        => true,
+			'hierarchical'       => false,
+			'menu_position'      => 2,
+			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ),
+	);
+
+	register_post_type( 'course topic', $args );
+}
+
+add_action( 'init', 'course_topic_init' );


### PR DESCRIPTION
…min menu

## Changes
_List Changes Introduced by this PR_
1. Registered CPT

## Purpose
Have designated posts for course topics

## Approach
Toolset Types is pay only now. I had to add the cpt in functions.php

## Learning
1. How to register a custom post type in functions.php
2. How to arrange custom post type in wp-admin dashboard
3. How to use '#' in menu to have a top level menu not link to anywhere but display submenu

_Links to blog posts, patterns, libraries or addons used to solve this problem_
1. https://developer.wordpress.org/reference/functions/register_post_type/
3. https://wordpress.stackexchange.com/questions/30303/how-make-top-level-menu-item-not-have-link-but-have-sub-menus-that-are-linked

Closes # 4 



