### PR TITLE
Changed supports from gutenberg back to editor

### DIFF
--- a/html/wp-content/themes/escapade-primer-child/functions.php
+++ b/html/wp-content/themes/escapade-primer-child/functions.php
@@ -434,7 +434,7 @@ function course_topic_init() {
 			'has_archive'        => true,
 			'hierarchical'       => false,
 			'menu_position'      => 2,
-			'supports'           => array( 'title', 'gutenberg', 'author', 'thumbnail', 'excerpt', 'comments' ),
+			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ),
 			'show_in_rest' => true,
 	);
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. In custom post type registration I changed gutenberg back to editor under supports.
2. Added show in rest arg

## Purpose
Changes custom post type editor from Classic to Gutenberg
## Approach
Calls the REST API to enable custom post types for Gutenberg

_Links to blog posts, patterns, libraries or addons used to solve this problem_
http://codismo.com/enable-gutenberg-custom-post-type-wordpress/



